### PR TITLE
Feat/setting Swagger & Spring Security 기본 설정 및 ResponseDTO 양식 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
+	implementation 'org.springdoc:springdoc-openapi-security:1.6.12'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/backend/dto/ResponseDTO.java
+++ b/src/main/java/com/example/backend/dto/ResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseDTO<T> {
+    private boolean success;
+    private String message;
+    private List<T> data;
+}

--- a/src/main/java/com/example/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/backend/global/config/SecurityConfig.java
@@ -1,0 +1,22 @@
+package com.example.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .formLogin().disable() //formLogin 인증 비활성화
+                .httpBasic().disable(); //httpBasic 인증 비활성화
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.example.backend.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI(@Value("${springdoc.version}") String appVersion) {
+        return new OpenAPI()
+                .components(new Components())
+                .info(new Info()
+                        .title("넘블 3팀 API")
+                        .version(appVersion)
+                        .description("넘블 프로젝트 API 명세서"));
+    }
+}

--- a/src/main/java/com/example/backend/global/config/WebMvcConfig.java
+++ b/src/main/java/com/example/backend/global/config/WebMvcConfig.java
@@ -1,0 +1,25 @@
+package com.example.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final long MAX_AGE_SECS = 3600;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        //모든 경로에 대해
+        registry.addMapping("/**")
+                //클라이언트 포트 설정
+                .allowedOrigins("http://localhost:3000")
+                //메서드 허용
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*") //모든 헤더 허용
+                .allowCredentials(true) // 모든 인증 정보 허용
+                .maxAge(MAX_AGE_SECS);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
+# Swagger
+springdoc.version=openapi_3_0
+springdoc.packages-to-scan=com.example.backend
+springdoc.api-docs.path=/api-docs/json
+springdoc.api-docs.resolve-schema-properties=true
 
+springdoc.swagger-ui.path=/api-docs
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
+springdoc.writer-with-default-pretty-printer=true
+springdoc.default-consumes-media-type=application/json;charset=UTF-8
+springdoc.default-produces-media-type=application/json;charset=UTF-8
+springdoc.cache.disabled=true


### PR DESCRIPTION
## Why need this change? 
- Swagger 적용 및 security 기본 설정
- ResponseDTO 양식 올려뒀어요
  - 향후 errorCode 변수 추가 가능성 있습니다

## Changes ✏️
- spring doc Open API를 사용한 **Swagger 3** 환경설정
  - 접속 주소: http://localhost:8080/api-docs
  - docs: https://springdoc.org/
- 사용예시
```java
@Tag(name = "user", description = "회원 API")
@RestController
@RequiredArgsConstructor
public class UserController {

    private final UserService userService;

    @ResponseStatus(HttpStatus.OK)
    @Operation(summary = "join", description = "회원가입")
    @ApiResponses({
            @ApiResponse(responseCode = "200", description = "OK"),
            @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
            @ApiResponse(responseCode = "404", description = "NOT FOUND"),
            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
    })
    @PostMapping("/join")
    public ResponseDTO<?> join(@RequestBody final UserJoinRequestDTO userJoinRequestDTO){
        //TODO validation 처리
        userService.create(userJoinRequestDTO);
        return ResponseDTO.builder().success(true).message("회원가입 처리되었습니다.").build();
    }
}
```

또는 파라미터 `ResponseEntity<?>`, 반환부 `ResponseEntity.builder()~` 사용해도 무방함

```java
@Data
@AllArgsConstructor
@NoArgsConstructor //없으면 swagger 에러남
@Schema
public class UserJoinDTO {

    @Schema(description = "회원 타입", defaultValue = "DEFAULT")
    @NotNull
    private UserType userType; // 기본 회원, 카카오 회원 구분

    ...
}
```

- response 에러 메시지 형식
![image](https://user-images.githubusercontent.com/43891587/200119135-656ee145-bd31-4d18-aae1-7f651a515945.png)

case1로 진행합니다

## Important (optional)
- 11/10까지 controller & DTO 작성~
