### PR TITLE
Feat/auth 예외 클래스 & 예외 타입 추가 및 서비스 구현

### DIFF
--- a/src/main/java/com/example/backend/global/exception/CustomErrorController.java
+++ b/src/main/java/com/example/backend/global/exception/CustomErrorController.java
@@ -1,0 +1,46 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.dto.ResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class CustomErrorController implements ErrorController {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST) //400
+    @ExceptionHandler(InvalidInputException.class)
+    public ResponseDTO<?> handleBadRequest(InvalidInputException ex){
+        return ResponseDTO.builder().success(false).message(ex.getMessage()).build();
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED) //401
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ResponseDTO<?> handleUnAuthorized(UnAuthorizedException ex){
+        return ResponseDTO.builder().success(false).message(ex.getMessage()).build();
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN) //403
+    @ExceptionHandler(ForbiddenException.class) //TODO
+    public ResponseDTO<?> handleForbidden(ForbiddenException ex){
+        return ResponseDTO.builder().success(false).message(ex.getMessage()).build();
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND) //404
+    @ExceptionHandler(EntityNotExistsException.class)
+    public ResponseDTO<?> handleNotFound(EntityNotExistsException ex){
+        return ResponseDTO.builder().success(false).message(ex.getMessage()).build();
+    }
+
+    //그 외에 놓친 예외들
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ResponseDTO<?> handleEtc(Exception ex){
+        log.error("Exception: {}", ex);
+        return  ResponseDTO.builder().success(false).message(ex.getMessage()).build();
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/EntityNotExistsException.java
+++ b/src/main/java/com/example/backend/global/exception/EntityNotExistsException.java
@@ -1,0 +1,18 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.global.exception.base.CustomException;
+import com.example.backend.global.exception.base.CustomExceptionType;
+
+public class EntityNotExistsException extends CustomException {
+
+    private EntityNotExistsExceptionType exceptionType;
+
+    public EntityNotExistsException(EntityNotExistsExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public CustomExceptionType getExceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/EntityNotExistsExceptionType.java
+++ b/src/main/java/com/example/backend/global/exception/EntityNotExistsExceptionType.java
@@ -1,0 +1,28 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.global.exception.base.CustomExceptionType;
+
+/**
+ * HttpStatus: NOT_FOUND
+ */
+public enum EntityNotExistsExceptionType implements CustomExceptionType {
+    NOT_FOUND_MEMBER(-105, "존재하지 않는 'user' 입니다.");
+
+    private int errorCode;
+    private String errorMessage;
+
+    EntityNotExistsExceptionType(int errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/ForbiddenException.java
+++ b/src/main/java/com/example/backend/global/exception/ForbiddenException.java
@@ -1,0 +1,13 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.global.exception.base.CustomException;
+import com.example.backend.global.exception.base.CustomExceptionType;
+
+public class ForbiddenException extends CustomException {
+
+
+    @Override
+    public CustomExceptionType getExceptionType() {
+        return null;
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/InvalidInputException.java
+++ b/src/main/java/com/example/backend/global/exception/InvalidInputException.java
@@ -1,0 +1,18 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.global.exception.base.CustomException;
+import com.example.backend.global.exception.base.CustomExceptionType;
+
+public class InvalidInputException extends CustomException {
+
+    private InvalidInputExceptionType exceptionType;
+
+    public InvalidInputException(InvalidInputExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public CustomExceptionType getExceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/InvalidInputExceptionType.java
+++ b/src/main/java/com/example/backend/global/exception/InvalidInputExceptionType.java
@@ -1,0 +1,31 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.global.exception.base.CustomExceptionType;
+
+/**
+ * HttpStatus: BAD_REQUEST
+ */
+public enum InvalidInputExceptionType implements CustomExceptionType {
+    ALREADY_EXISTS_EMAIL(-101,"'email'(body)이 이미 존재합니다."),
+    ALREADY_EXISTS_NICKNAME(-102,"'nickname'(body)이 이미 존재합니다."),
+    ALREADY_EXIST_EMAIL_AND_NICKNAME( -103,"'email'(body)과 'nickname'(body)이 이미 존재합니다."),
+    ACCOUNT_NOT_MATCH(-104,"'email'(body)또는 'password'(body)가 매칭되지 않습니다.");
+
+    private int errorCode;
+    private String errorMessage;
+
+    InvalidInputExceptionType(int errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/UnAuthorizedException.java
+++ b/src/main/java/com/example/backend/global/exception/UnAuthorizedException.java
@@ -1,0 +1,18 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.global.exception.base.CustomException;
+import com.example.backend.global.exception.base.CustomExceptionType;
+
+public class UnAuthorizedException extends CustomException {
+
+    private UnAuthorizedExceptionType exceptionType;
+
+    public UnAuthorizedException(UnAuthorizedExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public CustomExceptionType getExceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/UnAuthorizedExceptionType.java
+++ b/src/main/java/com/example/backend/global/exception/UnAuthorizedExceptionType.java
@@ -1,0 +1,28 @@
+package com.example.backend.global.exception;
+
+import com.example.backend.global.exception.base.CustomExceptionType;
+
+/**
+ * HttpStatus: UNAUTHORIZED
+ */
+public enum UnAuthorizedExceptionType implements CustomExceptionType {
+    USER_UN_AUTHORIZED(-199, "권한이 없는 페이지입니다.");
+
+    private int errorCode;
+    private String errorMessage;
+
+    UnAuthorizedExceptionType(int errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+
+    @Override
+    public int getErrorCode() {
+        return 0;
+    }
+}

--- a/src/main/java/com/example/backend/global/exception/base/CustomException.java
+++ b/src/main/java/com/example/backend/global/exception/base/CustomException.java
@@ -1,0 +1,7 @@
+package com.example.backend.global.exception.base;
+
+public abstract class CustomException extends RuntimeException{
+
+    public abstract CustomExceptionType getExceptionType();
+
+}

--- a/src/main/java/com/example/backend/global/exception/base/CustomExceptionType.java
+++ b/src/main/java/com/example/backend/global/exception/base/CustomExceptionType.java
@@ -1,0 +1,7 @@
+package com.example.backend.global.exception.base;
+
+public interface CustomExceptionType {
+
+    String getMessage();
+    int getErrorCode();
+}

--- a/src/main/java/com/example/backend/service/LoginServiceImpl.java
+++ b/src/main/java/com/example/backend/service/LoginServiceImpl.java
@@ -1,0 +1,78 @@
+package com.example.backend.service;
+
+import com.example.backend.domain.User;
+import com.example.backend.domain.enumType.UserType;
+import com.example.backend.dto.login.KaKaoAuthRequestDTO;
+import com.example.backend.global.exception.EntityNotExistsException;
+import com.example.backend.global.exception.EntityNotExistsExceptionType;
+import com.example.backend.global.exception.InvalidInputException;
+import com.example.backend.global.exception.InvalidInputExceptionType;
+import com.example.backend.global.security.TokenService;
+import com.example.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoginServiceImpl implements LoginService{
+
+    private final TokenService tokenService;
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+    @Override
+    public User defaultLogin(String email, String password) {
+        //비밀번호 일치 확인
+        User dbUser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotExistsException(EntityNotExistsExceptionType.NOT_FOUND_MEMBER));
+
+        if(passwordEncoder.matches(password, dbUser.getPassword())) return dbUser;
+        else throw new InvalidInputException(InvalidInputExceptionType.ACCOUNT_NOT_MATCH);
+    }
+
+    //TODO 프론트랑 협의 필요
+    @Override
+    public User kakaoLogin(KaKaoAuthRequestDTO loginDTO) {
+        getKakaoUserInfo(loginDTO.getKakaoAccessToken());
+
+        //가져온 값으로 DB id, type 검증
+        if(true){ //1. DB에 있는 회원이면 로그인 처리 후 토큰 발급
+            User testUser = User.builder().userType(UserType.KAKAO).build();
+            return testUser;
+        }
+        //2. DB에 없으면 null
+        else return null;
+    }
+
+    @Override
+    public User getKakaoUserInfo(String KakaoAccessToken) {
+        //TODO AT로 필요한 정보(id,이메일 정도?) 가져옴
+        return null;
+    }
+
+    @Override
+    public HashMap<String,String> authorize(User user) {
+        //토큰 2개 생성
+        final String AccessToken = tokenService.create(user); //AT 생성
+        final String RefreshToken = "sdfsdf"; //TODO RT 생성, 두개 한꺼번에 얻어오는게 낫나 음
+
+        HashMap<String,String> token = new HashMap<>();
+        token.put("AT", AccessToken);
+        token.put("RT", RefreshToken);
+
+        return token;
+    }
+
+    @Override
+    public void logout(Long userId) {
+
+    }
+
+}

--- a/src/main/java/com/example/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/example/backend/service/UserServiceImpl.java
@@ -1,0 +1,84 @@
+package com.example.backend.service;
+
+import com.example.backend.domain.User;
+import com.example.backend.dto.login.KaKaoAuthRequestDTO;
+import com.example.backend.dto.UserJoinRequestDTO;
+import com.example.backend.dto.UserModifyRequestDTO;
+import com.example.backend.global.exception.InvalidInputException;
+import com.example.backend.global.exception.InvalidInputExceptionType;
+import com.example.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    @Override
+    public void createDefaultUser(UserJoinRequestDTO userJoinRequestDTO) {
+        User user = userJoinRequestDTO.toEntity();
+
+         if(validateDuplicate(user.getEmail(), user.getNickname())){
+             //중복X -> 회원가입 처리
+             user.encodePassword(passwordEncoder);
+             userRepository.save(user);
+         }
+    }
+
+    @Transactional
+    @Override
+    public void createKakaoUser(KaKaoAuthRequestDTO snsUserDTO) {
+        User user = getKakaoUserInfo(snsUserDTO.getKakaoAccessToken());
+        //TODO 세팅 및 회원가입 처리
+    }
+
+    @Override
+    public User getKakaoUserInfo(String KakaoAccessToken) {
+        //TODO 카카오 사용자 정보 API에서 [id, 이메일, 핸드폰 번호, 이름, 프사(?)] 를 받아옴
+
+        return null;
+    }
+
+    //중복 검증
+    private boolean validateDuplicate(String email, String nickName) {
+        if(userRepository.existsByEmailAndNickname(email, nickName)){
+            throw new InvalidInputException(InvalidInputExceptionType.ALREADY_EXIST_EMAIL_AND_NICKNAME);
+        }
+        else if(userRepository.existsByEmail(email)){
+            throw new InvalidInputException(InvalidInputExceptionType.ALREADY_EXISTS_EMAIL);
+        }
+        else if(userRepository.existsByNickname(nickName)){
+            throw new InvalidInputException(InvalidInputExceptionType.ALREADY_EXISTS_NICKNAME);
+        }
+        return true;
+    }
+
+    @Transactional
+    @Override
+    public void delete(Long userId) {
+        userRepository.deleteById(userId);
+    }
+
+    @Override
+    public User getUser(Long userId) {
+        return null;
+    }
+
+    @Transactional
+    @Override
+    public User modifyUser(Long userId, UserModifyRequestDTO userModifyRequestDTO) {
+        //null인지 체크할 것. null이면 값 안바꿈
+        return null;
+    }
+
+
+}


### PR DESCRIPTION
## Why need this change? 
응답 결과를 Swagger API 문서에 나타내려면 에러 처리를 하는 메서드에 @ResponsStatus를 붙여줘야 합니다.
예를 들어... 한 개의 메서드로 모든 UserException을 처리해버리면 다양한 Status를 구분할 수 없기 때문에
swagger 연동을 위해서 http status 하나 당 exception 클래스 하나를 생성해서,  status별로 처리되도록 작성했습니다.

## Changes ✏️
- 베이스 되는 Exception class 및 enumType 추가
- user exception 추가되어있는 Exception class 및 type들 추가
- 누락된 UserServiceImpl 및 LoginServiceImpl 추가

## Important (optional)
- 공용 사용하면 될 듯 한데 어떠실까요 문제 있으면 알려주세요~
