### PR TITLE
Feat/auth user socialing 카카오 관련 로직 수정, User Entity 수정

### DIFF
--- a/src/main/java/com/example/backend/controller/LoginController.java
+++ b/src/main/java/com/example/backend/controller/LoginController.java
@@ -1,10 +1,13 @@
 package com.example.backend.controller;
 
 import com.example.backend.domain.User;
+import com.example.backend.domain.enumType.UserType;
 import com.example.backend.dto.login.AuthDTO;
 import com.example.backend.dto.login.SocialLoginRequestDTO;
 import com.example.backend.dto.ResponseDTO;
 import com.example.backend.dto.login.DefaultLoginRequestDTO;
+import com.example.backend.global.exception.InvalidInputException;
+import com.example.backend.global.exception.InvalidInputExceptionType;
 import com.example.backend.service.LoginService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -48,14 +51,18 @@ public class LoginController {
     }
 
     //TODO 서비스 구현
-    @Operation(summary = "카카오 로그인", description = "처음 로그인하는 경우 errorCode -112가 반환되며, /kakaojoin으로 재요청하면 됩니다.")
-    @PostMapping("/kakaologin")
+    @Operation(summary = "sns 로그인", description = "카카오: userType=KAKAO, 처음 로그인하는 경우 errorCode -112가 반환되며, region 설정 후 카카오 회원가입으로 재요청하면 됩니다.")
+    @PostMapping("/login/sns/{userType}")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
             @ApiResponse(responseCode = "404", description = "NOT FOUND")
     })
-    public ResponseEntity<?> kakaologin(@RequestBody final SocialLoginRequestDTO authRequestDTO){
+    public ResponseEntity<?> socialLogin(
+            @PathVariable String userType,
+            @RequestBody final SocialLoginRequestDTO authRequestDTO){
+
+        if(!userType.equals(UserType.KAKAO)) throw new InvalidInputException(InvalidInputExceptionType.INVALID_USERTYPE);
 
         User loginUser = loginService.kakaoLogin(authRequestDTO);
         HashMap<String, String> jwtMap = loginService.authorize(loginUser);
@@ -81,7 +88,7 @@ public class LoginController {
                 .body(response);
     }
 
-    //TODO AccessToken은 파괴가 안됨! 나중에 구현...
+    //TODO 프론트에서 AccessToken을 제거하고 이 url을 호출하면 RefreshToken을 DB에서 제거
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")

--- a/src/main/java/com/example/backend/controller/LoginController.java
+++ b/src/main/java/com/example/backend/controller/LoginController.java
@@ -2,7 +2,7 @@ package com.example.backend.controller;
 
 import com.example.backend.domain.User;
 import com.example.backend.dto.login.AuthDTO;
-import com.example.backend.dto.login.KaKaoAuthRequestDTO;
+import com.example.backend.dto.login.SocialLoginRequestDTO;
 import com.example.backend.dto.ResponseDTO;
 import com.example.backend.dto.login.DefaultLoginRequestDTO;
 import com.example.backend.service.LoginService;
@@ -55,7 +55,7 @@ public class LoginController {
             @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
             @ApiResponse(responseCode = "404", description = "NOT FOUND")
     })
-    public ResponseEntity<?> kakaologin(@RequestBody final KaKaoAuthRequestDTO authRequestDTO){
+    public ResponseEntity<?> kakaologin(@RequestBody final SocialLoginRequestDTO authRequestDTO){
 
         User loginUser = loginService.kakaoLogin(authRequestDTO);
         HashMap<String, String> jwtMap = loginService.authorize(loginUser);

--- a/src/main/java/com/example/backend/controller/UserController.java
+++ b/src/main/java/com/example/backend/controller/UserController.java
@@ -2,12 +2,10 @@ package com.example.backend.controller;
 
 import com.example.backend.domain.User;
 import com.example.backend.dto.*;
-import com.example.backend.dto.login.KaKaoAuthRequestDTO;
-import com.example.backend.dto.user.UserJoinRequestDTO;
+import com.example.backend.dto.login.SocialJoinRequestDTO;
+import com.example.backend.dto.user.UserDefaultJoinRequestDTO;
 import com.example.backend.dto.user.UserModifyRequestDTO;
 import com.example.backend.dto.user.UserProfileDTO;
-import com.example.backend.global.exception.ForbiddenException;
-import com.example.backend.global.exception.ForbiddenExceptionType;
 import com.example.backend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -38,7 +36,7 @@ public class UserController {
             @ApiResponse(responseCode = "201", description = "CREATED"),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST")
     })
-    public ResponseEntity<?> join(@RequestBody final UserJoinRequestDTO userJoinRequestDTO, UriComponentsBuilder uriBuilder){
+    public ResponseEntity<?> join(@RequestBody final UserDefaultJoinRequestDTO userJoinRequestDTO, UriComponentsBuilder uriBuilder){
         final User createdUser = userService.createDefaultUser(userJoinRequestDTO);
         return getCreatedResponseEntity(uriBuilder, createdUser.getId());
     }
@@ -52,9 +50,9 @@ public class UserController {
             @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
             @ApiResponse(responseCode = "404", description = "NOT FOUND")
     })
-    public ResponseEntity<?> kakaoJoin(@RequestBody final KaKaoAuthRequestDTO authRequestDTO, UriComponentsBuilder uriBuilder){
+    public ResponseEntity<?> kakaoJoin(@RequestBody final SocialJoinRequestDTO joinDTO, UriComponentsBuilder uriBuilder){
         //프론트에서 회원정보 동의해주면 AT 가지고 정보요청
-        final User createdUser = userService.createKakaoUser(authRequestDTO);
+        final User createdUser = userService.createKakaoUser(joinDTO);
         return getCreatedResponseEntity(uriBuilder, createdUser.getId());
     }
 

--- a/src/main/java/com/example/backend/controller/UserController.java
+++ b/src/main/java/com/example/backend/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.example.backend.controller;
 
 import com.example.backend.domain.User;
+import com.example.backend.domain.enumType.UserType;
 import com.example.backend.dto.*;
 import com.example.backend.dto.login.SocialJoinRequestDTO;
 import com.example.backend.dto.user.UserDefaultJoinRequestDTO;
 import com.example.backend.dto.user.UserModifyRequestDTO;
 import com.example.backend.dto.user.UserProfileDTO;
+import com.example.backend.global.exception.InvalidInputException;
+import com.example.backend.global.exception.InvalidInputExceptionType;
 import com.example.backend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -36,22 +39,25 @@ public class UserController {
             @ApiResponse(responseCode = "201", description = "CREATED"),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST")
     })
-    public ResponseEntity<?> join(@RequestBody final UserDefaultJoinRequestDTO userJoinRequestDTO, UriComponentsBuilder uriBuilder){
-        final User createdUser = userService.createDefaultUser(userJoinRequestDTO);
+    public ResponseEntity<?> join(@RequestBody final UserDefaultJoinRequestDTO userDefaultJoinRequestDTO, UriComponentsBuilder uriBuilder){
+        final User createdUser = userService.createDefaultUser(userDefaultJoinRequestDTO);
         return getCreatedResponseEntity(uriBuilder, createdUser.getId());
     }
 
     //TODO 서비스 구현
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "카카오 회원가입")
-    @PostMapping("/kakaojoin")
+    @Operation(summary = "sns 회원가입", description = "카카오: userType=KAKAO")
+    @PostMapping("/join/sns/{userType}")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
             @ApiResponse(responseCode = "404", description = "NOT FOUND")
     })
-    public ResponseEntity<?> kakaoJoin(@RequestBody final SocialJoinRequestDTO joinDTO, UriComponentsBuilder uriBuilder){
-        //프론트에서 회원정보 동의해주면 AT 가지고 정보요청
+    public ResponseEntity<?> socialJoin(
+            @PathVariable String userType,
+            @RequestBody final SocialJoinRequestDTO joinDTO, UriComponentsBuilder uriBuilder){
+        //프론트에서 회원정보 동의해주고 region, AT 가지고 회원가입 처리
+        if(!userType.equals(UserType.KAKAO)) throw new InvalidInputException(InvalidInputExceptionType.INVALID_USERTYPE);
         final User createdUser = userService.createKakaoUser(joinDTO);
         return getCreatedResponseEntity(uriBuilder, createdUser.getId());
     }
@@ -60,10 +66,11 @@ public class UserController {
         URI location = uriBuilder.path("/user/{id}")
                 .buildAndExpand(id).toUri();
 
+        //TODO location 추가
         return ResponseEntity.created(location).body(ResponseDTO.builder()
-                        .success(true).message("회원가입 처리되었습니다.")
-                        .data(null)
-                        .build());
+                .success(true).message("회원가입 처리되었습니다.")
+                .data(null)
+                .build());
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/example/backend/domain/User.java
+++ b/src/main/java/com/example/backend/domain/User.java
@@ -29,8 +29,8 @@ public class User {
 
     @NotNull
     private String email; // 아이디
-    @NotNull
-    private String password;
+
+    private String password; //카카오 유저는 비밀번호가 없음
 
     @NotNull
     @Column(name = "username")
@@ -70,6 +70,10 @@ public class User {
         password = passwordEncoder.encode(password);
     }
 
+    public void setId(Long id){
+        this.id = id;
+    }
+
     @Builder
     public User(@NotNull UserType userType, @NotNull String email, @NotNull String password, @NotNull String username, @NotNull String nickname, @NotNull String phoneNumber, @NotNull int region, String bio) {
         this.userType = userType;
@@ -82,7 +86,7 @@ public class User {
         this.bio = bio;
     }
 
-    //==연관관계 메서드==/
+    //==연관관계 메서드==//
     public void addSocialing(Socialing socialing){
         socialings.add(socialing);
         socialing.setUser(this);
@@ -93,7 +97,7 @@ public class User {
     }
 
 
-    //==수정 메서드==/
+    //==수정 메서드==//
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;

--- a/src/main/java/com/example/backend/dto/login/SocialJoinRequestDTO.java
+++ b/src/main/java/com/example/backend/dto/login/SocialJoinRequestDTO.java
@@ -6,10 +6,15 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Schema
-public class KaKaoAuthRequestDTO {
-    String kakaoAccessToken;
+public class SocialJoinRequestDTO {
+    @NotNull
+    String accessToken;
+    @NotNull
+    int region;
 }

--- a/src/main/java/com/example/backend/dto/login/SocialLoginRequestDTO.java
+++ b/src/main/java/com/example/backend/dto/login/SocialLoginRequestDTO.java
@@ -1,0 +1,18 @@
+package com.example.backend.dto.login;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema
+public class SocialLoginRequestDTO {
+    @NotNull
+    String accessToken;
+}

--- a/src/main/java/com/example/backend/dto/user/KakaoUserDTO.java
+++ b/src/main/java/com/example/backend/dto/user/KakaoUserDTO.java
@@ -1,0 +1,29 @@
+package com.example.backend.dto.user;
+
+import com.example.backend.domain.User;
+import com.example.backend.domain.enumType.UserType;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class KakaoUserDTO {
+    private Long id;//id, 사용자의 카카오 회원번호
+
+    //아래 정보들은 KakaoAccount 타입에서 받아오는 것
+    private String name; //동의 필요, name_needs_agreement가 true
+    private String email; //동의 필요, 예외처리 복잡
+
+    //로그인 하는 사용자에 따라 전화번호가 없는 계정은 동의 항목이 설정되어 있어도 전화번호를 조회할 수 없다
+    private String phoneNumber; //phone_number
+
+    //카카오 이메일은 값이 변할 수 있어서 아이디로 쓰기 적절하지 X
+    public User toEntity(int region) {
+        User user =  User.builder()
+                .userType(UserType.KAKAO).email(email).username(name).nickname(UUID.randomUUID().toString())
+                .phoneNumber(phoneNumber).region(region)
+                .build();
+        user.setId(id);
+        return user;
+    }
+}

--- a/src/main/java/com/example/backend/dto/user/UserDefaultJoinRequestDTO.java
+++ b/src/main/java/com/example/backend/dto/user/UserDefaultJoinRequestDTO.java
@@ -14,11 +14,7 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Schema
-public class UserJoinRequestDTO {
-
-    @Schema(description = "회원 타입", defaultValue = "DEFAULT")
-    @NotNull
-    private UserType userType; // 기본 회원, 카카오 회원 구분
+public class UserDefaultJoinRequestDTO {
 
     @Schema(description = "이메일(아이디)", defaultValue = "hello@numble.com")
     @NotNull
@@ -49,7 +45,7 @@ public class UserJoinRequestDTO {
 
     public User toEntity(){
         return User.builder()
-                .userType(userType).email(email).password(password).username(username).nickname(nickname)
+                .userType(UserType.DEFAULT).email(email).password(password).username(username).nickname(nickname)
                 .phoneNumber(phoneNumber).region(region).bio(bio)
                 .build();
     }

--- a/src/main/java/com/example/backend/global/exception/InvalidInputExceptionType.java
+++ b/src/main/java/com/example/backend/global/exception/InvalidInputExceptionType.java
@@ -9,6 +9,7 @@ public enum InvalidInputExceptionType implements CustomExceptionType {
     ALREADY_EXISTS_EMAIL(-101,"'email'(body)이 이미 존재합니다."),
     ALREADY_EXISTS_NICKNAME(-102,"'nickname'(body)이 이미 존재합니다."),
     ALREADY_EXIST_EMAIL_AND_NICKNAME( -103,"'email'(body)과 'nickname'(body)이 이미 존재합니다."),
+    ALREADY_EXISTS_KAKAO_USER(122, "해당 'user'는 이미 존재하는 'kakao'타입 계정입니다."),
     ACCOUNT_NOT_MATCH(-104,"'email'(body)또는 'password'(body)가 매칭되지 않습니다."),
     NOT_EXISTS_REFRESH_TOKEN(-110, "잘못된 Refresh Token 입니다."),
     INVALID_USERTYPE(-120, "잘못된 login/join user type 입니다.");

--- a/src/main/java/com/example/backend/global/exception/InvalidInputExceptionType.java
+++ b/src/main/java/com/example/backend/global/exception/InvalidInputExceptionType.java
@@ -10,7 +10,8 @@ public enum InvalidInputExceptionType implements CustomExceptionType {
     ALREADY_EXISTS_NICKNAME(-102,"'nickname'(body)이 이미 존재합니다."),
     ALREADY_EXIST_EMAIL_AND_NICKNAME( -103,"'email'(body)과 'nickname'(body)이 이미 존재합니다."),
     ACCOUNT_NOT_MATCH(-104,"'email'(body)또는 'password'(body)가 매칭되지 않습니다."),
-    NOT_EXISTS_REFRESH_TOKEN(-110, "잘못된 Refresh Token 입니다.");
+    NOT_EXISTS_REFRESH_TOKEN(-110, "잘못된 Refresh Token 입니다."),
+    INVALID_USERTYPE(-120, "잘못된 login/join user type 입니다.");
 
     private int errorCode;
     private String errorMessage;

--- a/src/main/java/com/example/backend/service/KakaoService.java
+++ b/src/main/java/com/example/backend/service/KakaoService.java
@@ -1,0 +1,11 @@
+package com.example.backend.service;
+
+import com.example.backend.dto.user.KakaoUserDTO;
+
+public interface KakaoService {
+
+    Long getUserId(String accessToken);
+
+    KakaoUserDTO getUserInfo(String accessToken);
+
+}

--- a/src/main/java/com/example/backend/service/LoginService.java
+++ b/src/main/java/com/example/backend/service/LoginService.java
@@ -1,7 +1,7 @@
 package com.example.backend.service;
 
 import com.example.backend.domain.User;
-import com.example.backend.dto.login.KaKaoAuthRequestDTO;
+import com.example.backend.dto.login.SocialLoginRequestDTO;
 
 import java.util.HashMap;
 
@@ -9,7 +9,7 @@ public interface LoginService {
 
     User defaultLogin(String email, String password);
 
-    User kakaoLogin(KaKaoAuthRequestDTO authRequestDTO);
+    User kakaoLogin(SocialLoginRequestDTO authRequestDTO);
 
     User getKakaoUserInfo(String KakaoAccessToken);
 

--- a/src/main/java/com/example/backend/service/LoginService.java
+++ b/src/main/java/com/example/backend/service/LoginService.java
@@ -11,8 +11,6 @@ public interface LoginService {
 
     User kakaoLogin(SocialLoginRequestDTO authRequestDTO);
 
-    User getKakaoUserInfo(String KakaoAccessToken);
-
     HashMap<String,String> authorize(User user);
 
     void logout(String email, String accessToken, String refreshToken);

--- a/src/main/java/com/example/backend/service/LoginServiceImpl.java
+++ b/src/main/java/com/example/backend/service/LoginServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.backend.service;
 
 import com.example.backend.domain.User;
-import com.example.backend.domain.enumType.UserType;
 import com.example.backend.dto.login.SocialLoginRequestDTO;
 import com.example.backend.global.exception.*;
 import com.example.backend.global.security.JwtSubject;
@@ -24,6 +23,7 @@ public class LoginServiceImpl implements LoginService{
     private final TokenService tokenService;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final KakaoService kakaoService;
 
     @Override
     public User defaultLogin(String email, String password) {
@@ -38,21 +38,14 @@ public class LoginServiceImpl implements LoginService{
     //TODO 프론트랑 협의 필요
     @Override
     public User kakaoLogin(SocialLoginRequestDTO loginDTO) {
-        getKakaoUserInfo(loginDTO.getAccessToken());
+        //AT로 카카오 사용자 정보(id) 가져온다
+        Long kakaoId = kakaoService.getUserId(loginDTO.getAccessToken());
 
-        //가져온 값으로 DB id, type 검증
-        if(true){ //1. DB에 있는 회원이면 로그인 처리 후 토큰 발급
-            User testUser = User.builder().userType(UserType.KAKAO).build();
-            return testUser;
-        }
-        //2. DB에 없으면 null
-        else throw new EntityNotExistsException(EntityNotExistsExceptionType.NOT_FOUND_KAKAO_USER);
-    }
-
-    @Override
-    public User getKakaoUserInfo(String KakaoAccessToken) {
-        //TODO AT로 필요한 정보(id,이메일 정도?) 가져옴
-        return null;
+        //가져온 값 중 '카카오의 회원번호'로 DB에 있는지 찾는다
+        //1. DB에 있는 회원이면 컨트롤러로 돌아가 인가처리
+        //2. 기존회원이 아니면 (region 필요) 에러코드
+        return userRepository.findById(kakaoId)
+                .orElseThrow(() -> new EntityNotExistsException(EntityNotExistsExceptionType.NOT_FOUND_KAKAO_USER));
     }
 
     @Transactional

--- a/src/main/java/com/example/backend/service/LoginServiceImpl.java
+++ b/src/main/java/com/example/backend/service/LoginServiceImpl.java
@@ -2,7 +2,7 @@ package com.example.backend.service;
 
 import com.example.backend.domain.User;
 import com.example.backend.domain.enumType.UserType;
-import com.example.backend.dto.login.KaKaoAuthRequestDTO;
+import com.example.backend.dto.login.SocialLoginRequestDTO;
 import com.example.backend.global.exception.*;
 import com.example.backend.global.security.JwtSubject;
 import com.example.backend.global.security.TokenService;
@@ -37,8 +37,8 @@ public class LoginServiceImpl implements LoginService{
 
     //TODO 프론트랑 협의 필요
     @Override
-    public User kakaoLogin(KaKaoAuthRequestDTO loginDTO) {
-        getKakaoUserInfo(loginDTO.getKakaoAccessToken());
+    public User kakaoLogin(SocialLoginRequestDTO loginDTO) {
+        getKakaoUserInfo(loginDTO.getAccessToken());
 
         //가져온 값으로 DB id, type 검증
         if(true){ //1. DB에 있는 회원이면 로그인 처리 후 토큰 발급

--- a/src/main/java/com/example/backend/service/UserService.java
+++ b/src/main/java/com/example/backend/service/UserService.java
@@ -1,15 +1,15 @@
 package com.example.backend.service;
 
 import com.example.backend.domain.User;
-import com.example.backend.dto.login.KaKaoAuthRequestDTO;
-import com.example.backend.dto.user.UserJoinRequestDTO;
+import com.example.backend.dto.login.SocialJoinRequestDTO;
+import com.example.backend.dto.user.UserDefaultJoinRequestDTO;
 import com.example.backend.dto.user.UserModifyRequestDTO;
 
 public interface UserService {
 
-    User createDefaultUser(UserJoinRequestDTO userDTO); //회원가입
+    User createDefaultUser(UserDefaultJoinRequestDTO userDTO); //회원가입
 
-    User createKakaoUser(KaKaoAuthRequestDTO authRequestDTO);
+    User createKakaoUser(SocialJoinRequestDTO authRequestDTO);
 
     void delete(String email); //회원 탈퇴
 

--- a/src/main/java/com/example/backend/service/UserService.java
+++ b/src/main/java/com/example/backend/service/UserService.java
@@ -15,8 +15,6 @@ public interface UserService {
 
     User getUser(String email, Long id); //내 프로필 조회
 
-    User getKakaoUserInfo(String KakaoAccessToken);
-
     User modify(String email, UserModifyRequestDTO userModifyRequestDTO);
 
     //모임신청

--- a/src/main/java/com/example/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/example/backend/service/UserServiceImpl.java
@@ -2,9 +2,11 @@ package com.example.backend.service;
 
 import com.example.backend.domain.Socialing;
 import com.example.backend.domain.User;
+import com.example.backend.domain.enumType.SocialStatus;
 import com.example.backend.domain.post.Post;
 import com.example.backend.domain.post.Social;
 import com.example.backend.dto.login.SocialJoinRequestDTO;
+import com.example.backend.dto.user.KakaoUserDTO;
 import com.example.backend.dto.user.UserDefaultJoinRequestDTO;
 import com.example.backend.dto.user.UserModifyRequestDTO;
 import com.example.backend.global.exception.*;
@@ -28,6 +30,7 @@ public class UserServiceImpl implements UserService{
     private final SocialRepository socialRepository;
     private final SocialingRepository socilaingRepository;
     private final PostRepository postRepository;
+    private final KakaoService kakaoService;
 
     private final PasswordEncoder passwordEncoder;
 
@@ -44,17 +47,14 @@ public class UserServiceImpl implements UserService{
 
     @Transactional
     @Override
-    public User createKakaoUser(SocialJoinRequestDTO kaKaoAuthRequestDTO) {
-        User user = getKakaoUserInfo(kaKaoAuthRequestDTO.getAccessToken());
-        return null;
-        //TODO 세팅 및 회원가입 처리
-    }
+    public User createKakaoUser(SocialJoinRequestDTO joinDTO) {
+        //카카오 사용자 정보 API에서 받아옴
+        KakaoUserDTO userDTO = kakaoService.getUserInfo(joinDTO.getAccessToken());
 
-    @Override
-    public User getKakaoUserInfo(String KakaoAccessToken) {
-        //TODO 카카오 사용자 정보 API에서 [id, 이메일, 핸드폰 번호, 이름, 프사(?)] 를 받아옴
-
-        return null;
+        validateSocialUserDuplicate(userDTO.getId(), userDTO.getEmail());
+        //중복X -> region 세팅 및 회원가입 처리
+        User user = userDTO.toEntity(joinDTO.getRegion());
+        return userRepository.save(user);
     }
 
     @Override
@@ -73,6 +73,14 @@ public class UserServiceImpl implements UserService{
         }
         else if(userRepository.existsByNickname(nickName)){
             throw new InvalidInputException(InvalidInputExceptionType.ALREADY_EXISTS_NICKNAME);
+        }
+    }
+
+    private void validateSocialUserDuplicate(Long id, String email){
+        boolean findUser = userRepository.existsById(id);
+        if(findUser) throw new InvalidInputException(InvalidInputExceptionType.ALREADY_EXISTS_KAKAO_USER);
+        else if(userRepository.existsByEmail(email)){
+            throw new InvalidInputException(InvalidInputExceptionType.ALREADY_EXISTS_EMAIL);
         }
     }
 
@@ -102,6 +110,10 @@ public class UserServiceImpl implements UserService{
 
         Social findSocial = socialRepository.findById(socialId)
                 .orElseThrow(() -> new EntityNotExistsException(EntityNotExistsExceptionType.NOT_FOUND_SOCIAL));
+
+        //모임이 꽉찬 상태면 x
+//        if(findSocial.getStatus() != SocialStatus.AVAILABLE) throw new ex
+        //중복 신청이면 x
 
         Socialing socialing = Socialing.createSocialing(findUser);
         findSocial.addSocialing(socialing);

--- a/src/main/java/com/example/backend/service/UserServiceImpl.java
+++ b/src/main/java/com/example/backend/service/UserServiceImpl.java
@@ -4,8 +4,8 @@ import com.example.backend.domain.Socialing;
 import com.example.backend.domain.User;
 import com.example.backend.domain.post.Post;
 import com.example.backend.domain.post.Social;
-import com.example.backend.dto.login.KaKaoAuthRequestDTO;
-import com.example.backend.dto.user.UserJoinRequestDTO;
+import com.example.backend.dto.login.SocialJoinRequestDTO;
+import com.example.backend.dto.user.UserDefaultJoinRequestDTO;
 import com.example.backend.dto.user.UserModifyRequestDTO;
 import com.example.backend.global.exception.*;
 import com.example.backend.repository.PostRepository;
@@ -33,8 +33,8 @@ public class UserServiceImpl implements UserService{
 
     @Transactional
     @Override
-    public User createDefaultUser(UserJoinRequestDTO userJoinRequestDTO) {
-        User user = userJoinRequestDTO.toEntity();
+    public User createDefaultUser(UserDefaultJoinRequestDTO userDefaultJoinRequestDTO) {
+        User user = userDefaultJoinRequestDTO.toEntity();
 
         validateDuplicate(user.getEmail(), user.getNickname());
         //중복X -> 회원가입 처리
@@ -44,8 +44,8 @@ public class UserServiceImpl implements UserService{
 
     @Transactional
     @Override
-    public User createKakaoUser(KaKaoAuthRequestDTO kaKaoAuthRequestDTO) {
-        User user = getKakaoUserInfo(kaKaoAuthRequestDTO.getKakaoAccessToken());
+    public User createKakaoUser(SocialJoinRequestDTO kaKaoAuthRequestDTO) {
+        User user = getKakaoUserInfo(kaKaoAuthRequestDTO.getAccessToken());
         return null;
         //TODO 세팅 및 회원가입 처리
     }

--- a/src/main/java/com/example/backend/service/social/KaKaoServiceImpl.java
+++ b/src/main/java/com/example/backend/service/social/KaKaoServiceImpl.java
@@ -1,0 +1,36 @@
+package com.example.backend.service.social;
+
+import com.example.backend.dto.user.KakaoUserDTO;
+import com.example.backend.service.KakaoService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+//TODO
+@Service
+public class KaKaoServiceImpl implements KakaoService {
+
+    private final String requestUrl = "https://kapi.kakao.com/v2/user/me"; //카카오 유저 API
+
+    @Value("${jwt.access.header}")
+    private String ACCESS_HEADER;
+
+    @Override
+    public Long getUserId(String accessToken) {
+        return null;
+    }
+
+    @Override
+    public KakaoUserDTO getUserInfo(String accessToken) {
+        //헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(ACCESS_HEADER, "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        //요청 보내기
+
+        //사용자 정보를 JsonNode로 변경하여 필요한 데이터만 추출하여 Dto로 담아 반환
+        return null;
+    }
+}


### PR DESCRIPTION
## Why need this change? 
- 카카오 로그인/회원가입 API 확장성 있게 수정
- 카카오 관련 로직 KakaoService로 분리

## Changes ✏️
- a6877c5 : UserService 수정 및 카카오 로직 분리, exceptionType 추가
- 97f8f25 : LoginService 수정 및 카카오 로직 분리
- eeeedd3 : KaKaoService, Impl, DTO 생성, UserEntity password `@Notnulll` 제거, setId 메서드 추가
  - #39 
- bcd715b : exceptionType 추가, 카카오 쪽 API path 수정
- 97c84ee : DTO 이름 수정 및 DTO 추가/교체

## Test checklist✅ (optional)
- 빌드 에러 x
