### PR TITLE
Feat/auth user socialing /refresh Security filter에서 제외

### DIFF
--- a/src/main/java/com/example/backend/controller/LoginController.java
+++ b/src/main/java/com/example/backend/controller/LoginController.java
@@ -33,6 +33,8 @@ public class LoginController {
     @Value("${jwt.refresh.expiration}")
     private Long REFRESH_EXP;
 
+    private String REFRESH_COOKIE = "refreshToken";
+
     private final LoginService loginService;
 
     @Operation(summary = "기본 로그인", description = "AccessToken은 헤더로, RefreshToken은 쿠키로 반환합니다.")
@@ -82,7 +84,7 @@ public class LoginController {
                 .build();
 
         //refresh token을 http only 쿠키에 담음
-        ResponseCookie cookie = ResponseCookie.from("refreshToken",tokenMap.get("RT"))
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, tokenMap.get("RT"))
                 .httpOnly(true)
                 .secure(false) //TODO SSL 인증서 필요해서 나중에
                 .sameSite("None")
@@ -91,6 +93,7 @@ public class LoginController {
                 .build();
 
         return ResponseEntity.ok()
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, HttpHeaders.AUTHORIZATION)
                 .header(HttpHeaders.AUTHORIZATION, tokenMap.get("AT"))
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(response);

--- a/src/main/java/com/example/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/backend/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests().antMatchers(
-                        "/", "/login", "/kakaologin", "/join", "/kakaojoin", "/swagger-ui/**", "/api-docs/**")
+                        "/", "/login", "/kakaologin", "/join", "/kakaojoin", "/refresh", "/swagger-ui/**", "/api-docs/**")
                 .permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/java/com/example/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/backend/global/config/SecurityConfig.java
@@ -22,6 +22,8 @@ import org.springframework.web.filter.CorsFilter;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private String REFRESH_COOKIE = "refreshToken";
+
     private final JwtLogoutHandler jwtLogoutHandler;
     private final TokenService tokenService;
 
@@ -45,7 +47,7 @@ public class SecurityConfig {
         http
                 .logout().permitAll()
                 .logoutUrl("/logout")
-                .deleteCookies("refreshToken") //로그아웃 후 쿠키 삭제
+                .deleteCookies(REFRESH_COOKIE) //로그아웃 후 쿠키 삭제
                 .addLogoutHandler(jwtLogoutHandler) //DB에서 RT 삭제
                 .logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.OK));
 

--- a/src/main/java/com/example/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/backend/global/security/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String TOKEN_PREFIX = "Bearer ";
 
-    private List<String> NOT_CHECK_URL = List.of("/login", "/kakaologin", "/join", "/kakaojoin");
+    private List<String> NOT_CHECK_URL = List.of("/login", "/kakaologin", "/join", "/kakaojoin", "/refresh");
 
     private final TokenService tokenService;
 
@@ -42,11 +42,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
         for(String url : NOT_CHECK_URL){
             if(url.equals(path)){
-                log.info("NOT_CHECK_URL입니다.");
                 return true;
             }
         }
-        log.info("NOT_CHECK_URL이 아닙니다.");
         return false;
     }
 

--- a/src/main/java/com/example/backend/global/security/JwtExceptionEntryPoint.java
+++ b/src/main/java/com/example/backend/global/security/JwtExceptionEntryPoint.java
@@ -4,6 +4,7 @@ import com.example.backend.dto.ErrorDTO;
 import com.example.backend.global.exception.UnAuthorizedExceptionType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -34,6 +35,7 @@ public class JwtExceptionEntryPoint implements AuthenticationEntryPoint {
                 .build();
             //to json
             String result = om.writeValueAsString(errorDTO);
+            response.setStatus(401);
             response.getWriter().write(result);
     }
 }

--- a/src/main/java/com/example/backend/global/security/TokenService.java
+++ b/src/main/java/com/example/backend/global/security/TokenService.java
@@ -84,6 +84,8 @@ public class TokenService {
 
     /**
      * jwt 검증 후 아이디(이메일) 추출(예외처리는 filter에서)
+     * 여기서 JwtException 발생하면 호출한 곳으로 돌아가므로
+     * 호출한 곳에서는 예외처리 필수
      * @param token
      * @return
      */

--- a/src/main/java/com/example/backend/service/LoginServiceImpl.java
+++ b/src/main/java/com/example/backend/service/LoginServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.backend.global.exception.*;
 import com.example.backend.global.security.JwtSubject;
 import com.example.backend.global.security.TokenService;
 import com.example.backend.repository.UserRepository;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -78,7 +79,12 @@ public class LoginServiceImpl implements LoginService{
     @Override
     public User getUserByRefreshToken(String refreshToken) {
         //RT 만료되었다면 validate 메서드에서 ->로그인 유도 401
-        JwtSubject jwtSubject = tokenService.validateAndGetSubject(refreshToken);
+        JwtSubject jwtSubject;
+        try{
+            jwtSubject = tokenService.validateAndGetSubject(refreshToken);
+        } catch(JwtException ex){
+            throw new UnAuthorizedException(UnAuthorizedExceptionType.REFRESH_TOKEN_UN_AUTHORIZED);
+        }
         //토큰 subject email로 User 가져옴
         return userRepository.findByEmail(jwtSubject.getEmail())
                 .orElseThrow(() -> new EntityNotExistsException(EntityNotExistsExceptionType.NOT_FOUND_USER));


### PR DESCRIPTION
## Why need this change? 
- /refresh filter 에서 제외 & 예외처리 추가

## Changes ✏️
- d96f682 : LoginServiceImpl의 getUserByRefreshToken메서드에서 예외처리 추가
- 59eae18 :  SecurityConfig에서 /refresh 제외 처리
- eb91de1 : AuthenticationException response Status 설정 안되어있던 것 수정
- 135b212 : JwtFilter에서 /refresh 제외 처리

## Test checklist✅ (optional)
- 빌드 에러 x
- 로컬에서 http 응답 테스트

![image](https://user-images.githubusercontent.com/43891587/203706081-9feae9a2-bbd7-44ba-bd23-7915f816f0e0.png)

![image](https://user-images.githubusercontent.com/43891587/203707119-d04caffc-5605-4aec-8ac9-48ac2f0e189b.png)
