### PR TITLE
Feat/comment 댓글 삭제 방법 변경

### DIFF
--- a/src/main/java/com/example/backend/controller/CommentController.java
+++ b/src/main/java/com/example/backend/controller/CommentController.java
@@ -97,7 +97,7 @@ public class CommentController {
     @ApiResponses(
         {@ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST")
-            , @ApiResponse(responseCode = "403", description = "Forbidden")
+            , @ApiResponse(responseCode = "403", description = "FORBIDDEN")
         ,@ApiResponse(responseCode = "404", description = "NOT FOUND")})
     @PutMapping("/comment/{commentId}")
     public ResponseDTO updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDTO commentRequestDTO, @AuthenticationPrincipal String userEmail) {

--- a/src/main/java/com/example/backend/domain/Comment.java
+++ b/src/main/java/com/example/backend/domain/Comment.java
@@ -49,7 +49,7 @@ public class Comment extends TimeAuditingEntity{
     private int refOrder; // 같은 그룹 내의 순서
     @Column(name = "parent_num")
     private Long parentNum; // 부모 댓글의 ID
-    private Boolean deleted; //삭제되었는지 여부
+    private Boolean deleted = false; //삭제되었는지 여부
 
     @Builder
     public Comment(User user, Post post, String contents, int cGroup, int level, int refOrder,

--- a/src/main/java/com/example/backend/dto/comment/CommentResponseDTO.java
+++ b/src/main/java/com/example/backend/dto/comment/CommentResponseDTO.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Schema(description = "댓글 조회 DTO")
+@Schema(description = "댓글 조회 DTO 삭제된 댓글일 시 deleted= true, user = null, content = 삭제된 댓글입니다.")
 @Getter
 @NoArgsConstructor
 public class CommentResponseDTO {
@@ -29,15 +29,23 @@ public class CommentResponseDTO {
     private Long parentNum;
     @Schema(description = "댓글의 생성 시간", defaultValue = "2022-10-22T17:13:39.566884")
     private LocalDateTime createDate;
+    @Schema(description = "해당 댓글의 삭제 여부", defaultValue = "false")
+    private Boolean deleted;
+
 
     public CommentResponseDTO(Comment comment) {
         this.commentId = comment.getId();
-        this.user = FeedUserDTO.toUserDTO(comment.getUser());
-        this.contents = comment.getContents();
         this.cGroup = comment.getCGroup();
         this.level = comment.getLevel();
         this.refOrder = comment.getRefOrder();
         this.parentNum = comment.getParentNum();
-        this.createDate = comment.getCreateDate();
+        if (comment.getDeleted()) {
+            this.contents = "삭제된 댓글입니다.";
+        } else {
+            this.contents = comment.getContents();
+            this.user = FeedUserDTO.toUserDTO(comment.getUser());
+            this.createDate = comment.getCreateDate();
+        }
+        deleted = comment.getDeleted();
     }
 }

--- a/src/main/java/com/example/backend/repository/CommentRepository.java
+++ b/src/main/java/com/example/backend/repository/CommentRepository.java
@@ -4,10 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.example.backend.domain.Comment;
 
@@ -22,12 +20,11 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     @Query("SELECT max(c.refOrder) FROM Comment c where c.cGroup =:cGroup and c.post.id =:post_id")
     Integer findLastRefOrderInGroup(@Param("cGroup") int cGroup, @Param("post_id") Long postId);
 
-    @Transactional
-    @Modifying
-    @Query("DELETE FROM Comment c where c.cGroup =:cGroup")
-    void deleteAllByCgroup(@Param("cGroup")int cGroup);
+    Optional<Comment> findByIdAndDeletedIsFalse(Long id);
 
-    Optional<Comment> findByIdAndPostId(Long id, Long postId);
+    Long countBycGroup(int cGroup);
+
+    Optional<Comment> findByIdAndPostIdAndDeletedIsFalse(Long id, Long postId);
 
     List<Comment> findAllByUserId(Long userId);
 }


### PR DESCRIPTION
## Why need this change? 
- 대댓글이 달린 댓글의 삭제 방법 변경
- 삭제된 댓글의 출력 로직 추가
- 삭제된 댓글에 대댓글 추가 및 수정 불가능하게 변경

## Changes ✏️
- 대댓글이 달린 댓글의 삭제 = deleted 컬럼 true로 변경
- 대댓글이 달리지 않은 댓글, 대댓글 = 바로 삭제 